### PR TITLE
TMS-1154: Remove tabindex from exhibition-item

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1154: Remove tabindex from exhibition-item
+
 ## [1.3.15] - 2025-04-30
 
 - TMS-1139: Add another link-button to CTA-component

--- a/assets/styles/ui-components/_exhibition-item.scss
+++ b/assets/styles/ui-components/_exhibition-item.scss
@@ -1,4 +1,6 @@
 .exhibition-item {
+    display: block;
+
     &__arrow-link {
         color: $color-ui-border-light;
     }

--- a/partials/shared/exhibition-item.dust
+++ b/partials/shared/exhibition-item.dust
@@ -1,6 +1,6 @@
 <div class="exhibition-item column is-6 is-4-desktop is-3-widescreen mb-3">
     {?exhibition.image}
-        <a href="{exhibition.permalink|url}" tabindex="-1">
+        <a href="{exhibition.permalink|url}">
             <span class="is-sr-only">
                 {exhibition.link_sr_text|html}
             </span>


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1154 Saavutettavuus: Näyttelyt-sivut
Task: https://hiondigital.atlassian.net/browse/TMS-1154

## Description

- Remove tabindex-attribute from exhibition-item
- Add display block for exhibition-item to make focus-styles visible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
