### PR TITLE
TMS-1273: Show exhibition start-date if its upcoming and no end-date is set

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1273: Show exhibition start-date if its upcoming and no end-date is set
+
 ## [1.6.2] - 2026-05-05
 
 - TMS-1263: Fix form button hover color

--- a/lib/Formatters/ExhibitionsFormatter.php
+++ b/lib/Formatters/ExhibitionsFormatter.php
@@ -82,20 +82,23 @@ class ExhibitionsFormatter implements Formatter {
             foreach ( $wp_query->posts as $post_item ) {
 
                 $start_date = strtotime( trim( \get_field( 'start_date', $post_item->ID ) ?? '' ) );
+                $end_date   = strtotime( trim( \get_field( 'end_date', $post_item->ID ) ?? '' ) );
+                $today      = strtotime( \current_time( 'Y-m-d' ) );
                 $dates      = '';
 
                 if ( ! empty( $start_date ) ) {
-                    $dates    = date( 'd.m.Y', $start_date );
-                    $end_date = strtotime( trim( \get_field( 'end_date', $post_item->ID ) ?? '' ) );
-
                     if ( ! empty( $end_date ) ) {
+                        $dates  = date( 'd.m.Y', $start_date );
                         $dates .= ' - ' . date( 'd.m.Y', $end_date );
+                    }
+                    elseif ( $start_date > $today ) {
+                        $dates = date( 'd.m.Y', $start_date );
                     }
                 }
 
                 $post_item->dates          = $dates;
                 $post_item->is_upcoming    = \get_field( 'is_upcoming', $post_item->ID );
-                $post_item->upcoming_badge = __( 'Upcoming', 'tms-theme-vapriikki' );
+                $post_item->upcoming_badge = \__( 'Upcoming', 'tms-theme-vapriikki' );
                 $data['posts'][]           = Exhibition::enrich_post( $post_item, true, true );
             }
         }

--- a/models/archive-exhibition.php
+++ b/models/archive-exhibition.php
@@ -563,14 +563,20 @@ class ArchiveExhibition extends BaseModel {
         $today  = new DateTime( 'now' );
         $today->setTime( '0', '0' );
 
-        if ( ! get_post_meta( $item->ID, 'start_date', true ) && ! get_post_meta( $item->ID, 'end_date', true ) ) {
+        if ( ! \get_post_meta( $item->ID, 'start_date', true ) && ! \get_post_meta( $item->ID, 'end_date', true ) ) {
             return true;
         }
 
-        $start_date = DateTime::createFromFormat( $format, get_post_meta( $item->ID, 'start_date', true ) );
+        $start_date = DateTime::createFromFormat( $format, \get_post_meta( $item->ID, 'start_date', true ) );
         $start_date->setTime( '0', '0' );
 
-        $end_date = DateTime::createFromFormat( $format, get_post_meta( $item->ID, 'end_date', true ) );
+        $end_value = \get_post_meta( $item->ID, 'end_date', true );
+
+        if ( empty( $end_value ) ) {
+            return $today >= $start_date;
+        }
+
+        $end_date = DateTime::createFromFormat( $format, $end_value );
         $end_date->setTime( '23', '59' );
 
         return $today >= $start_date && $today <= $end_date;
@@ -587,11 +593,11 @@ class ArchiveExhibition extends BaseModel {
         $format = 'Ymd';
         $today  = new DateTime( 'now' );
 
-        if ( ! get_post_meta( $item->ID, 'start_date', true ) ) {
+        if ( ! \get_post_meta( $item->ID, 'start_date', true ) ) {
             return false;
         }
 
-        $start_date = DateTime::createFromFormat( $format, get_post_meta( $item->ID, 'start_date', true ) );
+        $start_date = DateTime::createFromFormat( $format, \get_post_meta( $item->ID, 'start_date', true ) );
 
         return $start_date >= $today;
     }

--- a/models/archive-exhibition.php
+++ b/models/archive-exhibition.php
@@ -563,20 +563,36 @@ class ArchiveExhibition extends BaseModel {
         $today  = new DateTime( 'now' );
         $today->setTime( '0', '0' );
 
-        if ( ! \get_post_meta( $item->ID, 'start_date', true ) && ! \get_post_meta( $item->ID, 'end_date', true ) ) {
+        $start_value = \get_post_meta( $item->ID, 'start_date', true );
+        $end_value   = \get_post_meta( $item->ID, 'end_date', true );
+
+        if ( empty( $start_value ) && empty( $end_value ) ) {
             return true;
         }
 
-        $start_date = DateTime::createFromFormat( $format, \get_post_meta( $item->ID, 'start_date', true ) );
-        $start_date->setTime( '0', '0' );
+        // Guard unsupported end_date-only/invalid start_date cases to avoid DateTime fatal errors.
+        if ( empty( $start_value ) ) {
+            return true;
+        }
 
-        $end_value = \get_post_meta( $item->ID, 'end_date', true );
+        $start_date = DateTime::createFromFormat( $format, $start_value );
+
+        if ( ! $start_date ) {
+            return true;
+        }
+
+        $start_date->setTime( '0', '0' );
 
         if ( empty( $end_value ) ) {
             return $today >= $start_date;
         }
 
         $end_date = DateTime::createFromFormat( $format, $end_value );
+
+        if ( ! $end_date ) {
+            return $today >= $start_date;
+        }
+
         $end_date->setTime( '23', '59' );
 
         return $today >= $start_date && $today <= $end_date;

--- a/models/single-exhibition.php
+++ b/models/single-exhibition.php
@@ -40,16 +40,24 @@ class SingleExhibition extends BaseModel {
      * @param int $id The post ID.
      */
     public static function get_date( $id ) {
-        $start_date    = get_field( 'start_date', $id );
+        $start_date    = \get_field( 'start_date', $id );
+        $end_date      = \get_field( 'end_date', $id );
         $opening_times = '';
 
         if ( ! empty( $start_date ) ) {
-            $opening_times = self::reformat_datetime_string( $start_date );
-            $end_date      = get_field( 'end_date', $id );
+            // Show start date by itself only while it is still in the future.
+            if ( empty( $end_date ) ) {
+                $today = \current_time( 'Y-m-d' );
 
-            if ( ! empty( $end_date ) ) {
-                $opening_times .= ' - ' . self::reformat_datetime_string( $end_date );
+                if ( $start_date > $today ) {
+                    $opening_times = self::reformat_datetime_string( $start_date );
+                }
+
+                return $opening_times;
             }
+
+            $opening_times = self::reformat_datetime_string( $start_date );
+            $opening_times .= ' - ' . self::reformat_datetime_string( $end_date );
         }
 
         return $opening_times;


### PR DESCRIPTION
Project: Tampereen kaupunki, konsernihallinto / Tietohallintoyksikkö:
Project task: Tampere multisite support

Task: https://hiondigital.atlassian.net/browse/TMS-1273
Task title: Vapriikin Näyttelyt-sivu palauttaa virheen

## Description

Add functionality for upcoming exhibitions without an end-date

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)